### PR TITLE
fix: esm modules

### DIFF
--- a/src/default-cli.ts
+++ b/src/default-cli.ts
@@ -163,14 +163,26 @@ if (registers.length) {
 }
 
 // add ts-node registry for ts foyfile
+function isESM() {
+  try {
+    let pkg = fs.readJsonSync('./package.json')
+    return pkg.type === 'module'
+  } catch(e) {
+    return false
+  }
+}
 try {
   if (foyFiles.some((f) => f.endsWith('.ts')) && !require.extensions['.ts']) {
-    require('ts-node').register({
+    let options = {
       transpileOnly: true,
-      compilerOptions: {
-        module: 'commonjs',
-      },
-    })
+    }
+    /** if not ESM module override tsconfig module */
+    if (!isESM()) {
+      options['compilerOptions'] = {
+        module:  'commonjs',
+      }
+    }
+    require('ts-node').register(options)
   }
 } catch (error) {
   // ignore


### PR DESCRIPTION
fix: https://github.com/zaaack/foy/issues/18

@arimgibson I'm not sure this can fix your issues, but I guess it should work, please review, thanks. By the way, you can set your custom typescript registers by add  `alias foy=foy -r  'ts-node/register'` in your `.zshrc/.bashrc` file, this will override the built-in ts-node register.