### PR TITLE
fix: correct occured to occurred typo in task.ts comment

### DIFF
--- a/src/task.ts
+++ b/src/task.ts
@@ -29,7 +29,7 @@ export interface TaskDep<O = any> {
    */
   async?: boolean | number
   /**
-   * Whether rerun it when it occured in dependences tree more then once.
+   * Whether rerun it when it occurred in dependences tree more then once.
    */
   force?: boolean
   /**


### PR DESCRIPTION
## Summary
Fix typo in doc comment: `occured` → `occurred`

## Changes
- `src/task.ts:32`: Corrected spelling in JSDoc comment

## Testing
- Local syntax check passed ✅